### PR TITLE
Fix race condition in ICMP pinger

### DIFF
--- a/ping/pinger.go
+++ b/ping/pinger.go
@@ -164,10 +164,11 @@ func (p *pinger) ping() error {
 		return fmt.Errorf("Failed to marshal ICMP packet: %w", err)
 	}
 
+	p.inflight.Store(p.seq, sent)
 	if _, err := p.conn.WriteTo(msgB, &p.addr); err != nil {
+		p.inflight.Delete(p.seq)
 		return fmt.Errorf("Failed to send ICMP packet: %w", err)
 	}
-	p.inflight.Store(p.seq, sent)
 	p.seq = p.seq + 1
 	return nil
 }


### PR DESCRIPTION
We currently record an inflight packet *after* sending it out. This can lead to erroneously reporting a lost packet if the network connection is very fast and the sending go routine is interrupted between sending the packet and recoding that it is inflight. The receiver will drop the returning packet if it was not recorded as inflight.

This did not show up in testing as the overlay network on the test cluster seems to be "slow enough" to not run into this race condition.

## Summary

* Short summary of what's included in the PR
* Give special note to breaking changes

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
