### PR TITLE
Reduce chattiness of network-canary process

### DIFF
--- a/ping/manager.go
+++ b/ping/manager.go
@@ -102,7 +102,7 @@ func (m *Manager) Run(ctx context.Context) error {
 }
 func (m *Manager) schedulePingers(ctx context.Context) error {
 	l := logr.FromContextOrDiscard(ctx)
-	l.Info("Updating ping targets")
+	l.V(1).Info("Updating ping targets")
 	ips, err := m.lookUpTargets(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
We currently produce large amounts of logs like

```
1.6825706203312843e+09 | info | ping/manager.go:105 | Updating ping targets | {"version": "0.1.1"}
```

This line is logged regardless of whether there's actually any change in ping targets each time a round of pings is scheduled. This leads to quite significant amount of logs which serve very little purpose, since they're not particularly useful for debugging.

This PR changes the corresponding log statement to use `.V(1)` to disable this log message in normal operation.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
