### PR TITLE
Remove codeclimate upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,3 @@ jobs:
 
       - name: Run tests
         run: make test
-
-      - name: Upload code coverage report to Code Climate
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: 3ca00af82299473a23ec09eaa1039bd2e9b13db9670613f570b1a8998bb0c543
-        with:
-          coverageLocations: cover.out:gocov
-          prefix: github.com/${{ github.repository }}


### PR DESCRIPTION
## Summary

Remove codeclimate integration to unbreak tests.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
